### PR TITLE
[Fix] 스테이지 넘어가서도 무료 아이템 중복 사용 막는 것 수정

### DIFF
--- a/Assets/Scripts/UI/Reward/RewardFlowController.cs
+++ b/Assets/Scripts/UI/Reward/RewardFlowController.cs
@@ -37,12 +37,12 @@ public class RewardFlowController : MonoBehaviour
     {
         if (isLocked)
         { return; }
-        
 
-        if (freeItemUsed) 
+
+        if (freeItemUsed)
         {
             Debug.Log("이미 무료 아이템을 사용했습니다.");
-            return; 
+            return;
         }
 
         isPaidItem = false;
@@ -105,4 +105,8 @@ public class RewardFlowController : MonoBehaviour
         isLocked = false;
     }
 
+    public void ResetFreeItemState()
+    {
+        freeItemUsed = false;
+    }
 }

--- a/Assets/Scripts/UI/Reward/RewardUI.cs
+++ b/Assets/Scripts/UI/Reward/RewardUI.cs
@@ -26,6 +26,8 @@ public class RewardUI : MonoBehaviour
 
         gameObject.SetActive(true);
 
+        flowController.ResetFreeItemState();
+
         ResetSlots();
         HideDescription();
 


### PR DESCRIPTION
아이템 창이 제대로 무료 아이템을 중복 선택 할 수 있는 bool값을 제대로 false하지 않아서 생긴 일, RewardUI Open에 관련 bool 값을 false값으로 바꿔 선택을 할 수 있도록 수정