### PR TITLE
[Edit, Fix] 보스 라운드 때 팀 구성 버튼이 나오도록 수정 및 몇가지 버그 수정

### DIFF
--- a/Assets/Prefabs/UIPrefabs/RewardUI.prefab
+++ b/Assets/Prefabs/UIPrefabs/RewardUI.prefab
@@ -1111,7 +1111,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &2695240701852972085
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1128,6 +1128,7 @@ RectTransform:
   - {fileID: 3654204963545661833}
   - {fileID: 9201868291408694630}
   - {fileID: 1383338150578739990}
+  - {fileID: 15608345122979646}
   - {fileID: 8945603895281886919}
   - {fileID: 5598194238207697224}
   - {fileID: 8116639065399499942}
@@ -1228,6 +1229,9 @@ MonoBehaviour:
   flowController: {fileID: 0}
   rewardManager: {fileID: 0}
   skipConfirmUI: {fileID: 3217817272342078056}
+  nextStageButton: {fileID: 8189368427082072487}
+  recruitButton: {fileID: 7460505053189318166}
+  recruitUI: {fileID: 0}
   currentGold: {fileID: 164831140009571446}
 --- !u!1 &978302065595658852
 GameObject:
@@ -3177,6 +3181,85 @@ MonoBehaviour:
     m_VerticalOverflow: 1
     m_LineSpacing: 1
   m_Text: "\uC911\uC5F4"
+--- !u!1 &2213181003413215850
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 396847302353009010}
+  - component: {fileID: 9092646880710771340}
+  - component: {fileID: 5389416566243800274}
+  m_Layer: 5
+  m_Name: Text (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &396847302353009010
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2213181003413215850}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 15608345122979646}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9092646880710771340
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2213181003413215850}
+  m_CullTransparentMesh: 1
+--- !u!114 &5389416566243800274
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2213181003413215850}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Text
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 35
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 3
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: "\uD300 \uAD6C\uC131 \uBCC0\uACBD"
 --- !u!1 &2219749164054283101
 GameObject:
   m_ObjectHideFlags: 0
@@ -10109,6 +10192,139 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
+--- !u!1 &7460505053189318166
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 15608345122979646}
+  - component: {fileID: 2737757826755105027}
+  - component: {fileID: 4853190949172234222}
+  - component: {fileID: 3379088797006832397}
+  m_Layer: 5
+  m_Name: RecruitButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &15608345122979646
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7460505053189318166}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 396847302353009010}
+  m_Father: {fileID: 2695240701852972085}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 263.50708, y: 74.7875}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!222 &2737757826755105027
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7460505053189318166}
+  m_CullTransparentMesh: 1
+--- !u!114 &4853190949172234222
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7460505053189318166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.85098046, g: 0.85098046, b: 0.85098046, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &3379088797006832397
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7460505053189318166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4853190949172234222}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 931750059287818297}
+        m_TargetAssemblyTypeName: RewardUI, Assembly-CSharp
+        m_MethodName: OnClinkRecruit
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &7475811058038797127
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/RewardSkipConfirmUI.cs
+++ b/Assets/RewardSkipConfirmUI.cs
@@ -25,6 +25,11 @@ public class RewardSkipConfirmUI : MonoBehaviour
     private void OnBack()
     {
         gameObject.SetActive(false);
+
+        if(owner != null)
+        {
+            owner.OnSkipConfirmClosed();
+        }
         owner = null;
     }
 
@@ -34,6 +39,7 @@ public class RewardSkipConfirmUI : MonoBehaviour
 
         if(owner != null)
         {
+            owner.OnSkipConfirmClosed();
             owner.ProceedNextStage();
             owner = null;
         }

--- a/Assets/Scripts/Manager/BattleManager.cs
+++ b/Assets/Scripts/Manager/BattleManager.cs
@@ -431,8 +431,8 @@ public class BattleManager : MonoBehaviour
             Debug.Log("RewardUI 연결 안됨");
             return;
         }
-
-        RewardPanel.Open(hasDeadPlayer);
+        bool isBossStage = StageManager.Instance.CurrentRound == 5;
+        RewardPanel.Open(hasDeadPlayer, isBossStage);
     }
     // 25.12.30 한솔 부활 메커니즘
     public void ReviveCharacter(Character character, float reviveHP)

--- a/Assets/Scripts/UI/Reward/ReviveFlowController.cs
+++ b/Assets/Scripts/UI/Reward/ReviveFlowController.cs
@@ -43,7 +43,7 @@ public class ReviveFlowController : MonoBehaviour
 
         formationPanel.SetActive(false);
 
-        FindObjectOfType<RewardFlowController>()?.ResetFlow();
+        FindFirstObjectByType<RewardFlowController>()?.ResetFlow();
 
     }
 }

--- a/Assets/Scripts/UI/Reward/RewardUI.cs
+++ b/Assets/Scripts/UI/Reward/RewardUI.cs
@@ -17,10 +17,16 @@ public class RewardUI : MonoBehaviour
     [SerializeField] private RewardManager rewardManager;
     [SerializeField] private RewardSkipConfirmUI skipConfirmUI;
 
+    [SerializeField] private GameObject nextStageButton;
+    [SerializeField] private GameObject recruitButton;
+
+    [SerializeField] private RecruitUI recruitUI;
+
     [SerializeField] private Text currentGold;
 
+    private bool isSkipConfirmOpen = false;
 
-    public void Open(bool hasDeadTeam)
+    public void Open(bool hasDeadTeam, bool isBossRound)
     {
         if (gameObject.activeSelf)
         { return; }
@@ -41,7 +47,9 @@ public class RewardUI : MonoBehaviour
         SetUpFree(freeItems);
         SetUpPaid(paidItems);
 
+        UpdateButton(isBossRound);
     }
+
     private void ResetSlots()
     {
         foreach (var slot in paidSlots)
@@ -107,8 +115,22 @@ public class RewardUI : MonoBehaviour
 
     public void OnClickNextStage()
     {
+        if(isSkipConfirmOpen)
+        { return; }
+
         if (!flowController.FreeItemUsed)
-        { skipConfirmUI.Open(this); return; }
+        {
+            isSkipConfirmOpen = true;
+            skipConfirmUI.Open(this); 
+            return; 
+        }
+
+        ProceedNextStage();
+    }
+
+    public void OnSkipConfirmClosed()
+    {
+        isSkipConfirmOpen = false;
     }
 
     public void ProceedNextStage()
@@ -116,5 +138,27 @@ public class RewardUI : MonoBehaviour
         gameObject.SetActive(false);
         flowController.ResetFreeItemState();
         StageManager.Instance.OnRewardProcessCompleted();
+    }
+
+    private void UpdateButton(bool isBossRound)
+    {
+        if (nextStageButton != null)
+        {
+            nextStageButton.gameObject.SetActive(!isBossRound);
+        }
+        if (recruitButton != null)
+        {
+            recruitButton.gameObject.SetActive(isBossRound);
+        }
+    }
+
+    public void OnClinkRecruit()
+    {
+        Debug.Log("영입 버튼 클릭");
+        if (recruitUI != null)
+        {
+            Debug.LogError("recruitUI 연결되지 않음 !");
+        }
+        recruitUI.Open();
     }
 }


### PR DESCRIPTION
보스 라운드를 배틀 매니저에서 체크할 수 있기에, RewardUI의 Open 내부를 조금 수정해서 제작 
유물 장착하고, 다음 스테이지로 넘어가려하면 넘어가지 않는 버그
ㄴ OnClickNextStage()에 ProceedNextStage를 넣어, 다음 스테이지로 넘어가게 만듦

무료 아이템을 선택하지 않고 진행 시 처음에 두 번 클릭해야 무료 아이템을 선택하지 않았다는 UI가 뜨는 문제 
ㄴ RewardConfirmUI가 제대로 열렸는지 안열렸는지 확인하지 못하는 문제로 확인, 이를 해결할 bool값 하나와 그 값을 조절하여 하는 형식으로 바꿔 해결