### PR TITLE
[Fix] 유물이 현재 체력까지 건드리는 것 수정 및 2-5라운드 클리어 후 팀 구성 변경 버튼이 눌리지 않는 버그 수정

### DIFF
--- a/Assets/RecruitUI.cs
+++ b/Assets/RecruitUI.cs
@@ -308,6 +308,7 @@ public class RecruitUI : MonoBehaviour
 
         //종료
         placementPanel.SetActive(false);
+        rewardUI.isRecruitOpen = false;
         StageManager.Instance.OnRewardProcessCompleted();
     }
 
@@ -321,6 +322,7 @@ public class RecruitUI : MonoBehaviour
         if (rewardUI != null)
         {
             rewardUI.gameObject.SetActive(false);
+            rewardUI.isRecruitOpen = false;
         }
         StageManager.Instance.OnRewardProcessCompleted();
     }

--- a/Assets/Scripts/Item/Relic/RelicComponent.cs
+++ b/Assets/Scripts/Item/Relic/RelicComponent.cs
@@ -47,6 +47,7 @@ public class RelicComponent : MonoBehaviour
                 appliedHP = owner.BaseMaxHP * percent;
                 Debug.Log($"{owner.UnitName}에게 유물 장착, 체력 {appliedHP}만큼 증가");
                 owner.IncreaseMaxHP(appliedHP);
+                owner.Heal(appliedHP);
                 break;
             case RelicStateType.AttackBuff:
                 appliedAtk = owner.BaseAttack * percent;

--- a/Assets/Scripts/UI/Reward/RewardFlowController.cs
+++ b/Assets/Scripts/UI/Reward/RewardFlowController.cs
@@ -84,8 +84,8 @@ public class RewardFlowController : MonoBehaviour
         {
             target.GetComponent<RelicComponent>()?.Equip(relic);
             rewardManager.MarkRelicUsed(relic);
-            sucess = true;
             freeItemUsed = true;
+            sucess = true;
         }
 
         if (!sucess)

--- a/Assets/Scripts/UI/Reward/RewardUI.cs
+++ b/Assets/Scripts/UI/Reward/RewardUI.cs
@@ -25,7 +25,7 @@ public class RewardUI : MonoBehaviour
     [SerializeField] private Text currentGold;
 
     private bool isSkipConfirmOpen = false;
-    private bool isRecruitOpen = false;
+    public bool isRecruitOpen = false;
 
     public void Open(bool hasDeadTeam, bool isBossRound)
     {
@@ -180,9 +180,10 @@ public class RewardUI : MonoBehaviour
             skipConfirmUI.Open(this);
             return;
         }
-
+        Debug.Log("체크하기");
         if (isRecruitOpen)
         { return; }
+        Debug.Log("멈춤 지점");
 
         Debug.Log("영입 오픈");
         recruitUI.Open();

--- a/Assets/Scripts/Unit/BattleUnit.cs
+++ b/Assets/Scripts/Unit/BattleUnit.cs
@@ -152,7 +152,6 @@ public abstract class BattleUnit : MonoBehaviour
         }
         maxHP += amount;
         //늘어난 최대 체력만큼 현재 체력도 같이 회복
-        currentHP += amount;
         OnHpChanged?.Invoke(this, currentHP);
     }
 


### PR DESCRIPTION
유물을 변경할 때, 현재 체력도 같이 사라져 캐릭터의 체력이 -가 되는 버그 수정

2-5라운드에서 팀 구성 변경 버튼이 원활히 작동되지 않아 게임 진행이 불가능 했던 버그 수정